### PR TITLE
#159 JwtExceptionFilter 예외 처리 응답에 Object Mapper 적용

### DIFF
--- a/src/main/java/com/example/gatherplan/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/gatherplan/common/config/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
     }
 
     private Filter jwtExceptionFilter() {
-        return new JwtExceptionFilter();
+        return new JwtExceptionFilter(objectMapper);
     }
 
     private Filter jwtFilter() {

--- a/src/main/java/com/example/gatherplan/common/config/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/example/gatherplan/common/config/jwt/filter/JwtExceptionFilter.java
@@ -2,19 +2,25 @@ package com.example.gatherplan.common.config.jwt.filter;
 
 import com.example.gatherplan.common.config.jwt.exception.JwtTokenException;
 import com.example.gatherplan.common.exception.ErrorCode;
+import com.example.gatherplan.controller.exception.ErrorResp;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@RequiredArgsConstructor
 @Slf4j
 public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
@@ -33,12 +39,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
-        String jsonResponse = String.format("""
-            {
-                "code": "%s",
-                "message": "%s"
-            }
-            """, errorCode.getCode(), errorCode.getMessage());
+        String jsonResponse = objectMapper.writeValueAsString(ErrorResp.of(errorCode));
 
         response.getWriter().write(jsonResponse);
     }


### PR DESCRIPTION
### 연관 이슈
> 키워드와 이슈번호를 작성해주세요
- close #159 

### 리뷰 요구사항
> 리뷰어가 중점적으로 봐야할 부분을 작성해주세요
- ObjectMapper를 사용하여 ErrorResp를 JSON으로 변환하는 과정에서, 응답의 JSON 형식이 일관되게 생성되는지
- SecurityConfig에서 ObjectMapper가 JwtExceptionFilter로 정상적으로 주입되는지